### PR TITLE
Remove prConcurrentLimit from renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "prConcurrentLimit": 2
+  "extends": ["config:recommended"]
 }


### PR DESCRIPTION
## Summary

- Removes the `prConcurrentLimit: 2` setting from renovate.json
- Allows renovate to use the default concurrent PR limit from the recommended config
- Simplifies the configuration by removing unnecessary constraint

## Testing

- Renovate schema validation (checked in CI)
- Next renovate run will respect the updated configuration
- No code changes; configuration-only update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to use recommended settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->